### PR TITLE
fix: decrease replay timestamp precision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ test:
 	poetry run pytest -s
 	poetry run mypy
 
+profile:
+	poetry run pytest --durations=3
+
 serve-docs:
 	@cd docs;\
 	make html;\

--- a/aiosu/utils/binary.py
+++ b/aiosu/utils/binary.py
@@ -141,7 +141,7 @@ def unpack_timestamp(file: BinaryIO) -> datetime:
     :return: The unpacked timestamp.
     :rtype: datetime
     """
-    seconds = unpack_long(file) / 10000000 - 62135596800
+    seconds = unpack_long(file) // 10000000 - 62135596800
     return datetime.fromtimestamp(seconds, tz=timezone.utc)
 
 

--- a/tests/test_utils/test_replay.py
+++ b/tests/test_utils/test_replay.py
@@ -21,20 +21,17 @@ def replay_file(mode="osu"):
 
 def test_parse_replay(replay_file):
     for mode in modes:
-        data = BytesIO(replay_file(mode))
-        replay = aiosu.utils.replay.parse_file(data)
-        assert isinstance(replay, aiosu.models.ReplayFile)
+        with BytesIO(replay_file(mode)) as data:
+            replay = aiosu.utils.replay.parse_file(data)
+            assert isinstance(replay, aiosu.models.ReplayFile)
 
 
 def test_write_replay(replay_file):
     for mode in modes:
-        data = BytesIO(replay_file(mode))
-        replay = aiosu.utils.replay.parse_file(data)
-        rf = BytesIO()
-        aiosu.utils.replay.write_replay(rf, replay)
-        rf.seek(0)
-        new_replay = aiosu.utils.replay.parse_file(rf)
-        for attr in replay.model_fields:
-            if mode == "lazer" and attr == "played_at":
-                continue  # For some reason the played_at attribute is different by a couple seconds
-            assert getattr(replay, attr) == getattr(new_replay, attr)
+        with BytesIO(replay_file(mode)) as data:
+            replay = aiosu.utils.replay.parse_file(data)
+            with BytesIO() as f:
+                aiosu.utils.replay.write_replay(f, replay)
+                f.seek(0)
+                new_replay = aiosu.utils.replay.parse_file(f)
+                assert replay == new_replay


### PR DESCRIPTION
This caused issue with replays from lazer which have much higher precision on timestamps, causing values to potentially differ on export. This means the old workaround can be removed which was a major code smell of the old test.

<!--
  - Use [x] to complete the items
  - Add any relevant information you consider useful
-->

## Self-check

- [x] The changes are tested with [pre-commit](https://pre-commit.com/)
- [x] The changes pass unit testing with [pytest](https://pre-commit.com/)
- [x] The changes pass [mypy](http://mypy-lang.org/)
