### PR TITLE
fix: failed scores seem to have urls now

### DIFF
--- a/aiosu/models/lazer.py
+++ b/aiosu/models/lazer.py
@@ -177,11 +177,12 @@ class LazerScore(BaseModel):
         """
         if not self.id:
             return None
-        return (
-            f"https://osu.ppy.sh/scores/{self.id}"
-            if self.type == "solo_score"
-            else f"https://osu.ppy.sh/scores/{self.mode.name_api}/{self.best_id}"
-        )
+        if self.type == "solo_score":
+            return f"https://osu.ppy.sh/scores/{self.id}"
+
+        if not self.best_id:  # Legacy URL format
+            return None
+        return f"https://osu.ppy.sh/scores/{self.mode.name_api}/{self.best_id}"
 
     @property
     def replay_url(self) -> Optional[str]:

--- a/aiosu/models/lazer.py
+++ b/aiosu/models/lazer.py
@@ -175,7 +175,7 @@ class LazerScore(BaseModel):
         :return: Link to the score on the osu! website
         :rtype: Optional[str]
         """
-        if (not self.id and not self.best_id) or not self.passed:
+        if not self.id:
             return None
         return (
             f"https://osu.ppy.sh/scores/{self.id}"

--- a/aiosu/models/score.py
+++ b/aiosu/models/score.py
@@ -171,7 +171,7 @@ class Score(BaseModel):
         :return: Link to the score on the osu! website
         :rtype: Optional[str]
         """
-        if (not self.id and not self.best_id) or not self.passed:
+        if not self.id:
             return None
         return (
             f"https://osu.ppy.sh/scores/{self.id}"

--- a/aiosu/models/score.py
+++ b/aiosu/models/score.py
@@ -173,11 +173,12 @@ class Score(BaseModel):
         """
         if not self.id:
             return None
-        return (
-            f"https://osu.ppy.sh/scores/{self.id}"
-            if self.type == "solo_score"
-            else f"https://osu.ppy.sh/scores/{self.mode.name_api}/{self.best_id}"
-        )
+        if self.type == "solo_score":
+            return f"https://osu.ppy.sh/scores/{self.id}"
+
+        if not self.best_id or not self.passed:  # Legacy URL format
+            return None
+        return f"https://osu.ppy.sh/scores/{self.mode.name_api}/{self.best_id}"
 
     @property
     def replay_url(self) -> Optional[str]:


### PR DESCRIPTION
<!--
  - Use [x] to complete the items
  - Add any relevant information you consider useful
-->

## Self-check

- [x] The changes are tested with [pre-commit](https://pre-commit.com/)
- [x] The changes pass unit testing with [pytest](https://pre-commit.com/)
- [x] The changes pass [mypy](http://mypy-lang.org/)
